### PR TITLE
Create test_sv_naming_23_f.sv

### DIFF
--- a/sv_tests/test_sv_naming_23_f.sv
+++ b/sv_tests/test_sv_naming_23_f.sv
@@ -1,0 +1,13 @@
+module test_new_m;
+   bit req,grnt;
+   bit clk;
+
+   property p_req_cycle;
+           @(posedgeclk) $rose (req) |-> ##[1:3] grnt;
+   endproperty : p_req_cycle
+
+   a_new : assert property ((@posedge clk) p_req_cycle);
+       else $error ("Fail");
+
+
+endmodule : test_new_m


### PR DESCRIPTION
PySlint: Violation: [SVA_MISSING_FAIL_AB]: Missing FAIL Action block - use $error/`uvm_error:
  // BAD - missing FAIL action block in SVA
  a_var1 : assert property (@(posedge clk) var1);
PySlint: Violation: [SVA_NO_PASS_AB]: Avoid using PASS Action block - likely to cause too many vacuous prints:
  // BAD - avoid using PASS action block in SVA
  // It usually leads to too many vacuous prints